### PR TITLE
Replace Albert Sans with system font stack

### DIFF
--- a/packages/main/src/_variables.scss
+++ b/packages/main/src/_variables.scss
@@ -1,6 +1,8 @@
 :root {
 	color-scheme: light dark;
-	--font-family: "Albert Sans", sans-serif;
+	--font-family:
+		ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+		"Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 	--border: light-dark(#d4d4d8, #27272a);
 	--color: light-dark(#09090b, #fafafa);
 	--color-primary: light-dark(#fafafa, #09090b);

--- a/packages/main/src/compoments/_typography.scss
+++ b/packages/main/src/compoments/_typography.scss
@@ -1,5 +1,3 @@
-@import url(https://fonts.bunny.net/css?family=albert-sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i,800,800i,900,900i);
-
 html {
 	font-size: 16px;
 }


### PR DESCRIPTION
Remove external font import and use native system fonts for better performance and consistency across platforms.